### PR TITLE
Documentation and Optional Docker 24.0.6 Installation in `setup.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,166 @@
+[![CI](https://github.com/christopherkeim/rust-cli-template/actions/workflows/ci.yaml/badge.svg)](https://github.com/christopherkeim/rust-cli-template/actions/workflows/ci.yaml)
+![Cargo Version](https://img.shields.io/badge/cargo-1.76.0-red.svg)
+![Clap](https://img.shields.io/badge/clap-4.5.1-red.svg)
+
 # rust-cli-template
-A template repository for Rust-based command-line interface applications.
+
+This repository implements a simple Rust command-line interface application that converts webpages to markdown files.
+
+# Quickstart 🦀 🚀 ✨
+
+This repository is a GitHub Template that you can use to create a new repository for Rust-based command-line applications It comes pre-configured to use `cargo 1.76.0` with automated setup for `Ubuntu 20.04/22.04`.
+
+To get started, you can:
+
+1. Simply click `Use this template` in the top right corner of this repository, or
+
+2. Clone this repository onto your machine with:
+
+```bash
+git clone https://github.com/christopherkeim/rust-cli-template.git
+```
+
+# Setup
+
+**Note: this template targets Ubuntu 20.04/22.04 development environments for automated setup.**
+
+1. Once you have local copy of this repository in your development environment, navigate into this directory and run the `setup.sh` script:
+
+```bash
+cd rust-cli-template/
+bash setup.sh
+```
+
+If you would like to include `Docker 24.0.6` in your development environment, you can run:
+
+```bash
+bash setup.sh --docker
+```
+
+2. You can ensure that the code currently passes the provided tests with:
+
+```bash
+make test
+```
+
+3. You can directly try the CLI application with:
+
+```bash
+cargo run -- \
+  --url https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/book/first-edition/error-handling.html \
+  --file rust_error_handling.md
+```
+
+> This webpage is an excellent resource on error handling rust 😊.
+
+# `Makefile` Development Workflow Automation
+
+I like to use a `Makefile` to automate parts of my development workflow - this allows you to alias parts of your development process like linting, formatting, testing, and building binaries.
+
+The `Makefile` in this repository comes with the following commands:
+
+1. `make build`
+
+```bash
+cargo build --release
+```
+
+2. `make clean`
+
+```bash
+cargo clean
+```
+
+3. `make doc`
+
+```bash
+cargo doc --no-deps --open
+```
+
+4. `make lint`
+
+```bash
+cargo clippy
+```
+
+5. `make format`
+
+```bash
+cargo fmt
+```
+
+6. `make test`
+
+```bash
+cargo test
+```
+
+# `ci.yaml` Continuous Integration
+
+This repository has continuous integration that runs when Pull Requests are opened to the `main` branch.
+
+**Note that GitHub Action runners come pre-installed with cargo 1.76.0 (latest)**
+
+1. Checks out the source code into the runner VM
+
+2. Formats source code
+
+3. Tests source code
+
+4. Builds a release binary for deployment (commented out - replace with your deployment strategy)
+
+# Notes
+
+## Dev and Release Profiles
+
+Cargo has two main profiles: the `dev` profile Cargo uses when you run `cargo build` and the `release` profile Cargo uses when you run c`argo build --release`. The dev profile is defined with good defaults for development, and the release profile has good defaults for release builds.
+
+These profile names might be familiar from the output of your builds:
+
+```bash
+$ cargo build
+    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+$ cargo build --release
+    Finished release [optimized] target(s) in 0.0s
+The dev and release are these different profiles used by the compiler.
+```
+
+## `opt-level` (Cargo.toml)
+
+By adding `[profile.*]` sections for any profile you want to customize, you override any subset of the default settings. For example, here are the default values for the `opt-level` setting for the `dev` and `release` profiles:
+
+Filename: Cargo.toml
+
+```toml
+[profile.dev]
+opt-level = 0
+
+[profile.release]
+opt-level = 3
+```
+
+The `opt-level` setting controls the number of optimizations Rust will apply to your code, with a range of `0` to `3`. Applying more optimizations extends compiling time, so if you’re in development and compiling your code often, you’ll want fewer optimizations to compile faster even if the resulting code runs slower.
+
+## Documentation (Overall Rust)
+
+The best documentation with very clear examples is Rust By Example: https://doc.rust-lang.org/rust-by-example/index.html
+
+## rustc Targets
+
+`rustc` is a cross-compiler by default. This means that you can use any compiler to build for any architecture. The list of targets are the possible architectures that you can build for can be seen with:
+
+```bash
+rustc --print target-list
+```
+
+**The rustc Book**: https://doc.rust-lang.org/rustc/targets/index.html
+
+## Cross-compiling for Raspberry Pi Targets
+
+https://jakewharton.com/cross-compiling-static-rust-binaries-in-docker-for-raspberry-pi/
+
+## The Cargo Book
+
+Documentation on Rust's package manager `cargo`.
+
+https://doc.rust-lang.org/cargo/index.html

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@
 # 
 # Targets:
 #   - cargo 1.76.0
-#   - Docker 24.0.6
+#   - Docker 24.0.6 (optional with `--docker`)
 #
 # Requirements:
 #   - Ubuntu 20.04/22.04
@@ -17,6 +17,61 @@
 
 # Pull the current machine's distro for GPG key targeting
 readonly DISTRO="$(lsb_release -d | awk -F ' ' '{print tolower($2)}')"
+
+readonly PACKAGE="setup.sh"
+
+WITH_DOCKER=false
+
+show_help() {
+  cat <<END
+  Sets up Rust (cargo 1.76.0) environment for command-line 
+  application development on Ubuntu 20.04/22.04.
+
+  ${PACKAGE} [options] [arguments]
+
+  options:
+  -h, --help                Display help message
+  -d, --docker              Includes Docker 24.0.6 in installation
+END
+
+  exit 0
+}
+
+while getopts 'hd-:' flag; do
+  case "${flag}" in
+    h) show_help ;;
+    d) WITH_DOCKER=true ;;
+    -)
+      # Prefix substring removal matching "*="
+      LONG_OPTARG_VALUE="${OPTARG#*=}"
+      case ${OPTARG} in
+        help)
+          show_help
+          ;;
+        docker)
+          WITH_DOCKER=true
+          ;;
+        docker*)
+          echo "No arg for --${OPTARG} option" >&2
+          exit 2
+          ;;
+        help*)
+          echo "No arg allowed for --${OPTARG} option" >&2; 
+          exit 2
+          ;;
+        *)
+          echo "Unknown option --$OPTARG" >&2
+          exit 2 
+          ;;
+      esac 
+      ;;
+    # getopts already reported the unknown option error, so exit
+    \?) exit 2 ;;
+  esac
+done
+shift $((OPTIND-1))
+
+readonly WITH_DOCKER
 
 
 # -----------------------------------------------------------------------------------------------------------
@@ -109,6 +164,10 @@ fi
 # -----------------------------------------------------------------------------------------------------------
 # 3) Docker Install: here we'll install Docker
 # -----------------------------------------------------------------------------------------------------------
+
+if [[ $WITH_DOCKER == false ]]; then
+  exit 0
+fi
 
 # -----------------------------------------------------------------------------------------------------------
 # 3.1) Set up the repository: Before you install Docker Engine for the first time on a new host machine, 

--- a/setup.sh
+++ b/setup.sh
@@ -77,7 +77,7 @@ fi
 
 # Ensure gnupg is installed on the machine
 if ( which gpg > /dev/null ); then
-  echo 'make is already installed 🟢'
+  echo 'gnupg is already installed 🟢'
 else
   echo 'Installing gnugp 🔧'
   sudo apt install -y gnupg

--- a/src/files.rs
+++ b/src/files.rs
@@ -85,9 +85,9 @@ mod tests {
         assert_eq!(result, expected_error);
     }
 
-    #[test]
     /// Empty file name string
-    fn invalid_file_name_returns_early_with_error() {
+    #[test]
+    fn empty_file_name_returns_early_with_error() {
         let result: String =
             write_markdown_file("# Hello testing\n".to_string(), &mut "".to_string())
                 .unwrap_err()
@@ -98,6 +98,7 @@ mod tests {
         assert_eq!(result, expected_error);
     }
 
+    /// Valid markdown and file name
     #[test]
     fn valid_markdown_and_file_name_successfully_write_to_file() {
         let test_directory: tempfile::TempDir =

--- a/src/html.rs
+++ b/src/html.rs
@@ -70,8 +70,8 @@ mod tests {
         assert_eq!(result, expected_error);
     }
 
-    #[test]
     /// Invalid URL
+    #[test]
     fn invalid_url_returns_early_with_error() {
         let result: String = extract_html_from_webpage("invalid_webpage.com".to_string())
             .unwrap_err()
@@ -82,6 +82,7 @@ mod tests {
         assert_eq!(result, expected_error);
     }
 
+    /// Valid request
     #[test]
     fn valid_request_returns_valid_html_string() {
         let result: String = match extract_html_from_webpage("https://www.google.com".to_string()) {
@@ -94,6 +95,7 @@ mod tests {
         assert!(result.starts_with(expected_doctype));
     }
 
+    /// Invalid request
     #[test]
     fn invalid_request_returns_request_failure() {
         let result: String =

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -49,8 +49,8 @@ mod tests {
         assert_eq!(result, expected_error);
     }
 
+    /// Valid html
     #[test]
-    /// Empty file name string
     fn converts_valid_html_to_valid_markdown() {
         let result: String = match convert_html_to_markdown("<h1>Header!</h1>".to_string()) {
             Ok(markdown) => markdown,


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

1. Updated `README.md` with `Quickstart`, `Setup`, `Makefile`, `Continuous Integration` and `Notes` sections. 
2. `setup.sh` now optionally installs `Docker 24.0.6` by passing it `-d` or `--docker`:

## Testing

Testing on `Ubuntu 20.04/22.04` passes for optional `Docker 24.0.6` installation.

## Dependencies Added:

None

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- DELETE OR COMMENT OUT THE OTHER CHOICES -->

- [x] Documentation (non-breaking change which improves documentation)
- [x] Refactoring / Cleanup (non-breaking change which does not add functionality or fix issues)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (or no changes needed).
- [x] All new and existing tests are passing.
